### PR TITLE
 Update TF code to handle lambda deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ secrets.tf
 
 # Idea
 .idea/*
+
+# Generated lambda bundle
+lambda.zip

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -21,13 +21,13 @@ PATTERN
 resource "aws_cloudwatch_event_target" "events" {
   target_id = "${var.name}-events"
   rule      = "${aws_cloudwatch_event_rule.events.name}"
-  arn       = "${module.lambda.function_arn}"
+  arn       = "${aws_lambda_function.lambda.arn}"
 }
 
 resource "aws_lambda_permission" "events" {
   statement_id  = "${var.name}-events"
   action        = "lambda:InvokeFunction"
-  function_name = "${module.lambda.function_name}"
+  function_name = "${aws_lambda_function.lambda.function_name}"
   principal     = "events.amazonaws.com"
   source_arn    = "${aws_cloudwatch_event_rule.events.arn}"
 }
@@ -42,13 +42,18 @@ resource "aws_cloudwatch_event_rule" "schedule" {
 resource "aws_cloudwatch_event_target" "schedule" {
   target_id = "${var.name}-schedule"
   rule      = "${aws_cloudwatch_event_rule.schedule.name}"
-  arn       = "${module.lambda.function_arn}"
+  arn       = "${aws_lambda_function.lambda.arn}"
 }
 
 resource "aws_lambda_permission" "schedule" {
   statement_id  = "${var.name}-schedule"
   action        = "lambda:InvokeFunction"
-  function_name = "${module.lambda.function_name}"
+  function_name = "${aws_lambda_function.lambda.function_name}"
   principal     = "events.amazonaws.com"
   source_arn    = "${aws_cloudwatch_event_rule.schedule.arn}"
+}
+
+resource "aws_cloudwatch_log_group" "system_logs" {
+  name              = "/aws/lambda/${aws_lambda_function.lambda.function_name}"
+  retention_in_days = "${var.cloudwatch_log_retention}"
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,16 +1,80 @@
-module "lambda" {
-  source = "github.com/claranet/terraform-aws-lambda?ref=v0.9.1"
+data "aws_caller_identity" "current" {}
 
-  function_name = "${var.name}"
-  description   = "Manages ASG instance replacement"
-  handler       = "main.lambda_handler"
-  runtime       = "python3.6"
-  timeout       = "${var.timeout}"
+data "aws_region" "current" {}
 
-  source_path = "${path.module}/lambda"
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
 
-  attach_policy = true
-  policy        = "${data.aws_iam_policy_document.lambda.json}"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda"
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = "${var.name}"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+# Attach a policy for logs.
+
+data "aws_iam_policy_document" "logs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.name}:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "logs" {
+  name   = "${var.name}-logs"
+  policy = "${data.aws_iam_policy_document.logs.json}"
+}
+
+resource "aws_iam_policy" "lambda" {
+  name   = "${var.name}-lambda"
+  policy = "${data.aws_iam_policy_document.lambda.json}"
+}
+
+resource "aws_iam_policy_attachment" "logs" {
+  name       = "${var.name}-logs"
+  roles      = ["${aws_iam_role.lambda.name}"]
+  policy_arn = "${aws_iam_policy.logs.arn}"
+}
+
+resource "aws_iam_policy_attachment" "lambda" {
+  name       = "${var.name}-lambda"
+  roles      = ["${aws_iam_role.lambda.name}"]
+  policy_arn = "${aws_iam_policy.lambda.arn}"
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name                  = "${var.name}"
+  description                    = "Manages ASG instance replacement"
+  filename                       = "${data.archive_file.lambda.output_path}"
+  handler                        = "main.lambda_handler"
+  memory_size                    = 128
+  reserved_concurrent_executions = 0
+  role                           = "${aws_iam_role.lambda.arn}"
+  runtime                        = "python3.6"
+  source_code_hash               = "${base64sha256(file(data.archive_file.lambda.output_path))}"
+  timeout                        = "${var.timeout}"
 }
 
 data "aws_iam_policy_document" "lambda" {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -35,9 +35,10 @@ data "aws_ami" "amz_linux_2" {
   }
 }
 
-# module "instance_replacement" {
-#   source = "../../module"
-# }
+module "instance_replacement" {
+  source = "../../module"
+  name   = "ASGIR-${random_string.rstring.result}"
+}
 
 module "vpc" {
   source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"

--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,23 @@
+variable "cloudwatch_log_retention" {
+  description = "The number of days to retain Cloudwatch Logs for this instance."
+  type        = "string"
+  default     = "30"
+}
+
 variable "name" {
   description = "Name to use for resources"
+  type        = "string"
   default     = "tf-aws-asg-instance-replacement"
 }
 
 variable "schedule" {
   description = "Schedule for running the Lambda function"
+  type        = "string"
   default     = "rate(1 minute)"
 }
 
 variable "timeout" {
   description = "Lambda function timeout"
+  type        = "string"
   default     = "60"
 }


### PR DESCRIPTION
Moves deployment of lambda function away from 3rd party module to use Terraform resources directly.  Terraform `archive_file` data resource is used to create the Lambda bundle and has been confirmed to be compatible with Window and Linux platforms.
Adds creation of CloudWatch Log Group to the module, to allow for log retention configuration.