### PR TITLE
Adjust Lambda IAM permissions to only allow access to managed ASGs

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -79,15 +79,56 @@ resource "aws_lambda_function" "lambda" {
 
 data "aws_iam_policy_document" "lambda" {
   statement {
+    effect = "Deny"
+
+    actions = [
+      "autoscaling:ResumeProcesses",
+      "autoscaling:SetInstanceHealth",
+      "autoscaling:SuspendProcesses",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEqualsIgnoreCase"
+      variable = "autoscaling:ResourceTag/InstanceReplacement"
+
+      values = [
+        "0",
+        "disabled",
+        "false",
+        "no",
+        "off",
+      ]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:ResumeProcesses",
+      "autoscaling:SetInstanceHealth",
+      "autoscaling:SuspendProcesses",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "autoscaling:ResourceTag/InstanceReplacement"
+      values   = ["*"]
+    }
+  }
+
+  statement {
     effect = "Allow"
 
     actions = [
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:ResumeProcesses",
-      "autoscaling:SetInstanceHealth",
-      "autoscaling:SuspendProcesses",
-      "autoscaling:UpdateAutoScalingGroup",
       "elasticloadbalancing:DescribeInstanceHealth",
       "elasticloadbalancing:DescribeTargetHealth",
     ]


### PR DESCRIPTION
Change adjusts the Lambda function IAM permissions as follows:  

- Access has been denied for explicitly disabled ASGs (those with the `InstanceReplacement` tag set any of the disabled values).
- Access as been allowed only to ASGs with any other value in the `InstanceReplacement` tag
- Access to ASGs without a `InstanceReplacement` tag will be implicitly denied.

This change should ensure that the tool will not be able to effect and unmanaged ASG